### PR TITLE
Co2

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -17,8 +17,8 @@ ARDUINO_LIBS = LiquidCrystal_I2C idDHTLib Wire Time DS3232RTC Timer OneButton MQ
 AVRDUDE      = /usr/bin/avrdude
 AVRDUDE_CONF = /etc/avrdude.conf
 
-CPPFLAGS += -DDEBUG #-DDEBUG_VERBOSE
-CFLAGS += -DDEBUG #-DDEBUG_VERBOSE
+CPPFLAGS += -DDEBUG -DDEBUG_PARAM #-DDEBUG_VERBOSE
+CFLAGS += -DDEBUG  -DDEBUG_PARAM #-DDEBUG_VERBOSE
 include $(ARDMK_DIR)/Arduino.mk
 
 # !!! Important. You have to use make ispload to upload when using ISP programmer

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -17,8 +17,8 @@ ARDUINO_LIBS = LiquidCrystal_I2C idDHTLib Wire Time DS3232RTC Timer OneButton MQ
 AVRDUDE      = /usr/bin/avrdude
 AVRDUDE_CONF = /etc/avrdude.conf
 
-CPPFLAGS += -DDEBUG -DDEBUG_PARAM #-DDEBUG_VERBOSE
-CFLAGS += -DDEBUG  -DDEBUG_PARAM #-DDEBUG_VERBOSE
+CPPFLAGS += -DDEBUG -DDEBUG_PARAM -DCALIB_FAST #-DDEBUG_VERBOSE
+CFLAGS += -DDEBUG  -DDEBUG_PARAM -DCALIB_FAST #-DDEBUG_VERBOSE
 include $(ARDMK_DIR)/Arduino.mk
 
 # !!! Important. You have to use make ispload to upload when using ISP programmer

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -11,7 +11,7 @@ ISP_PORT = /dev/ttyACM*
 # Required libraries for project
 ARDUINO_LIB_PATH = $(ARDUINO_DIR)/hardware/arduino/avr/libraries
 USER_LIB_PATH = $(ARDUINO_SKETCHBOOK)/libraries
-ARDUINO_LIBS = LiquidCrystal_I2C idDHTLib Wire Time DS3232RTC Timer OneButton
+ARDUINO_LIBS = LiquidCrystal_I2C idDHTLib Wire Time DS3232RTC Timer OneButton MQ135
 
 # Avrdude conf (flash board)
 AVRDUDE      = /usr/bin/avrdude

--- a/sw/eep_param.cpp
+++ b/sw/eep_param.cpp
@@ -1,0 +1,92 @@
+#include <avr/eeprom.h>
+#include "eep_param.h"
+
+struct calib {
+	uint16_t atmoco2;
+	float r0;
+	float rl;
+};
+
+struct calib EEMEM eepcalib;
+struct calib calib;
+
+Param::Param()
+{
+	_base = 0;
+	_size = 30;
+}
+
+Param::Param(unsigned long base, int size)
+{
+	_base = base;
+	_size = size;
+}
+
+int Param::readParam()
+{
+	eeprom_read_block(&calib, &eepcalib, sizeof(struct calib));
+#ifdef DEBUG_PARAM
+	Serial.println("read eeprom");
+	Serial.print("atmoco2=");
+	Serial.println(calib.atmoco2);
+	Serial.print("r0=");
+	Serial.println(calib.r0);
+	Serial.print("rl=");
+	Serial.println(calib.rl);
+#endif
+	return 0;
+}
+
+int Param::saveParam()
+{
+	calib.atmoco2 = _atmoco2;
+	calib.r0 = _r0;
+	calib.rl = _rl;
+#ifdef DEBUG_PARAM
+	Serial.println("write eeprom");
+	Serial.print("atmoco2=");
+	Serial.println(calib.atmoco2);
+	Serial.print("r0=");
+	Serial.println(calib.r0);
+	Serial.print("rl=");
+	Serial.println(calib.rl);
+#endif
+	eeprom_update_block(&calib, &eepcalib, sizeof(struct calib));
+	return 0;
+}
+
+uint16_t Param::getAtmoco2()
+{
+	return _atmoco2;
+}
+
+void Param::setAtmoco2(int ppm)
+{
+	_atmoco2 = ppm;
+}
+
+void Param::setAtmoco2(float ppm)
+{
+	_atmoco2 = (uint16_t) ppm;
+}
+
+float Param::getR0()
+{
+	return _r0;
+}
+
+void Param::setR0(float r)
+{
+	_r0 = r;
+}
+
+float Param::getRl()
+{
+	return _rl;
+}
+
+void Param::setRl(float r)
+{
+	_rl = r;
+}
+

--- a/sw/eep_param.cpp
+++ b/sw/eep_param.cpp
@@ -24,7 +24,8 @@ Param::Param(unsigned long base, int size)
 
 int Param::readParam()
 {
-	eeprom_read_block(&calib, &eepcalib, sizeof(struct calib));
+	eeprom_read_block((void *)&calib, (const void *)&eepcalib,
+			  sizeof(struct calib));
 #ifdef DEBUG_PARAM
 	Serial.println("read eeprom");
 	Serial.print("atmoco2=");
@@ -34,6 +35,9 @@ int Param::readParam()
 	Serial.print("rl=");
 	Serial.println(calib.rl);
 #endif
+	_atmoco2 = calib.atmoco2;
+	_r0 = calib.r0;
+	_rl = calib.rl;
 	return 0;
 }
 
@@ -51,7 +55,8 @@ int Param::saveParam()
 	Serial.print("rl=");
 	Serial.println(calib.rl);
 #endif
-	eeprom_update_block(&calib, &eepcalib, sizeof(struct calib));
+	eeprom_update_block((const void *)&calib, (void *)&eepcalib,
+			    sizeof(struct calib));
 	return 0;
 }
 

--- a/sw/eep_param.h
+++ b/sw/eep_param.h
@@ -1,0 +1,41 @@
+#ifndef EEP_PARAM_H
+#define EEP_PARAM_H
+#if ARDUINO >= 100
+ #include "Arduino.h"
+#else
+ #include "WProgram.h"
+#endif
+
+#define EEP_CALIB_MAGIC 0x6c9a
+#define EEP_MISC_MAGIC 0x6c9b
+
+class Param {
+private:
+	uint16_t _base;
+	uint16_t _magic;
+	uint16_t _size;
+
+	uint16_t _atmoco2;
+	float _r0;
+	float _rl;
+
+public:
+	Param(void);
+	Param(unsigned long base, int size);
+	unsigned long getBase(void);
+	void setBase(unsigned long);
+	int getSize(void);
+	void setSize(int);
+	int getMagic(void);
+	void setMagic(int);
+	int readParam(void);
+	int saveParam();
+	float getR0(void);
+	void setR0(float);
+	float getRl(void);
+	void setRl(float);
+	uint16_t getAtmoco2(void);
+	void setAtmoco2(int);
+	void setAtmoco2(float);
+};
+#endif

--- a/sw/inside.cpp
+++ b/sw/inside.cpp
@@ -29,6 +29,7 @@ setup:
 #include <Timer.h>
 #include <Time.h>
 #include <MQ135.h>
+#include "eep_param.h"
 #include "rtc.h"
 #include "keypad.h"
 
@@ -76,6 +77,7 @@ LiquidCrystal_I2C lcd(0x38, 16, 2);
 idDHTLib DHTLib(TEMP_PIN, idDHTLib::DHT22);
 MQ135 co2sensor(CO2_PIN);
 Timer t;
+Param prm(0, 12);
 
 int refreshEvent, ledEvent, sensorEvent;
 int screen_id = FIRST_SCREEN;
@@ -101,6 +103,9 @@ void setup()
 	rtc_init();
 
 	init_keypad();
+
+	/* read calibration parameters from eeprom */
+	prm.readParam();
 
 	/* Configure LED pin as output */
 	pinMode(LED_PIN, OUTPUT);
@@ -364,7 +369,7 @@ static void handle_calibration_events()
 	case CALIBRATION_RZERO_STORING:
 		if (up) {
 			co2sensor.setRzero(sumr0 / 3);
-			/* TBD: store RZero value in EEPROM */
+			prm.saveParam();
 			context = DISPLAY_STANDARD;
 		}
 		if (dwn) {

--- a/sw/inside.cpp
+++ b/sw/inside.cpp
@@ -307,7 +307,11 @@ static void handle_calibration_events()
 		calib_state++;
 	case CALIBRATION_RZERO:
 		if (up) {
+#ifdef CALIB_FAST
+			heatEvt = t.after(2000, heatingCompleted);
+#else
 			heatEvt = t.after(1800000, heatingCompleted);
+#endif
 			calib_state++;
 		}
 		if (dwn)
@@ -332,13 +336,21 @@ static void handle_calibration_events()
 		lcd.print("CO2 calibration:");
 		lcd.setCursor(0,1);
 		lcd.print("measuring...");
+#ifdef CALIB_FAST
+		measEvt = t.after(500, startMeasure);
+#else
 		measEvt = t.after(300000, startMeasure);
+#endif
 		calib_state++;
 	case CALIBRATION_RZERO_MEASURING_1:
 		if (meas_tmo) {
 			sumr0 = co2sensor.measureCorrectedRZero(temp,
 								humidity);
+#ifdef CALIB_FAST
+			measEvt = t.after(500, startMeasure);
+#else
 			measEvt = t.after(5000, startMeasure);
+#endif
 			calib_state++;
 		}
 		break;
@@ -346,7 +358,11 @@ static void handle_calibration_events()
 		if (meas_tmo) {
 			sumr0 += co2sensor.measureCorrectedRZero(temp,
 								 humidity);
+#ifdef CALIB_FAST
+			measEvt = t.after(500, startMeasure);
+#else
 			measEvt = t.after(5000, startMeasure);
+#endif
 			calib_state++;
 		}
 		break;

--- a/sw/inside.cpp
+++ b/sw/inside.cpp
@@ -143,6 +143,10 @@ static void get_sensor_data()
 {
 	int sts = 0;
 
+	/* read only when useful */
+	if (context != DISPLAY_STANDARD)
+		return;
+
 	/* Get sensor values */
 	lightlvl = analogRead(LIGHT_PIN);
 	sts = DHTLib.acquireAndWait();

--- a/sw/inside.cpp
+++ b/sw/inside.cpp
@@ -257,7 +257,6 @@ static void handle_calibration_events()
 
 	switch(calib_state) {
 	case CALIBRATION_RZERO_ENTRY:
-		r0 = co2sensor.getRzero();
 		lcd.clear();
 		lcd.setCursor(0, 0);
 		lcd.print("CO2 calibration:");
@@ -328,21 +327,24 @@ static void handle_calibration_events()
 		calib_state++;
 	case CALIBRATION_RZERO_MEASURING_1:
 		if (meas_tmo) {
-			sumr0 = co2sensor.measureRZero();
+			sumr0 = co2sensor.measureCorrectedRZero(temp,
+								humidity);
 			measEvt = t.after(5000, startMeasure);
 			calib_state++;
 		}
 		break;
 	case CALIBRATION_RZERO_MEASURING_2:
 		if (meas_tmo) {
-			sumr0 += co2sensor.measureRZero();
+			sumr0 += co2sensor.measureCorrectedRZero(temp,
+								 humidity);
 			measEvt = t.after(5000, startMeasure);
 			calib_state++;
 		}
 		break;
 	case CALIBRATION_RZERO_MEASURING_3:
 		if (meas_tmo) {
-			sumr0 += co2sensor.measureRZero();
+			sumr0 += co2sensor.measureCorrectedRZero(temp,
+								 humidity);
 #ifdef DEBUG
 			Serial.print("Calibrated R0 = ");
 			Serial.println(sumr0 / 3);

--- a/sw/keypad.h
+++ b/sw/keypad.h
@@ -13,10 +13,13 @@
 #define VALID_LONG_PRESS (1 << 1)
 #define UP_PRESS (1 << 2)
 #define DOWN_PRESS (1 << 3)
+#define HEAT_TIMEOUT (1 << 4)
+#define MEAS_TIMEOUT (1 << 5)
 
 /* display context */
 #define DISPLAY_STANDARD 0 /* normal display mode */
 #define DISPLAY_SETTINGS 1 /* in settings and config context */
+#define DISPLAY_CALIBRATION 2 /* in calbration mode */
 
 extern int context;
 extern int events;


### PR DESCRIPTION
Manage CO2 sensor and allow loading/storing of the sensor params from/to eeprom
New settings menu is created to set atmospheric co2 reference value and to perform calibration.
Rload of sensor is still fixed at 10kOhm

Debug flag is also enabled to speed up calibration (30s approx. total) which is bad => needs to be removed later to perform real calibration

The code from this pull request depends on the MQ135Lib (git@github.com:py06/MQ135.git forked from git@github.com:ViliusKraujutis/MQ135.git) and avr-libc eeprom functions